### PR TITLE
fix(ci): Limit commitsar action to PRs

### DIFF
--- a/.github/workflows/commit_validation.yaml
+++ b/.github/workflows/commit_validation.yaml
@@ -6,10 +6,6 @@ name: Commit Compliance
 on:
   pull_request:
     branches: [ main ]
-  push:
-    branches: [ main ]
-permissions:
-  contents: read
 jobs:
   validate-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It fails to fetch the correct commits when running on main, as that does not seem to be its intended use.